### PR TITLE
Support py34

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,6 @@ language: python
 env: # These should match the tox env list
     - TOXENV=py26 PATH=/opt/python/2.6.9/bin:$PATH
     - TOXENV=py27
+    - TOXENV=py34
 install: pip install tox --use-mirrors
 script: tox

--- a/README.md
+++ b/README.md
@@ -15,11 +15,10 @@ TL;DR: `pip install yelp_uri`
 Make a well-encoded URI from user input.
 
 ```python
-    >>> weird_uri = b'http://münch.com/münch?one=m%C3%BCnch#m%FCnch'
-
+    >>> weird_uri = u'http://münch.com/münch?one=m%C3%BCnch#m%FCnch'.encode('UTF-8')
     >>> import yelp_uri.encoding as E
     >>> well_encoded = E.recode_uri(weird_uri)
-    >>> print well_encoded
+    >>> print(well_encoded)
     http://xn--mnch-0ra.com/m%C3%BCnch?one=m%C3%BCnch#m%C3%BCnch
 
 ```
@@ -27,9 +26,9 @@ Make a well-encoded URI from user input.
 Make a user-readable url, from either a well-encoded url or user input:
 
 ```python
-    >>> print E.decode_uri(well_encoded)
+    >>> print(E.decode_uri(well_encoded))
     http://münch.com/münch?one=münch#münch
-    >>> print E.decode_uri(weird_uri)
+    >>> print(E.decode_uri(weird_uri))
     http://münch.com/münch?one=münch#münch
 
 ```
@@ -44,7 +43,7 @@ Make a user-readable url, from either a well-encoded url or user input:
     ...     Follow @YelpCincy on Twitter (http://twitter.com/YelpCincy)
     ... '''
     >>> from yelp_uri.search import url_regex
-    >>> for url in url_regex.finditer(plaintext): print url.group()
+    >>> for url in url_regex.finditer(plaintext): print(url.group())
     http://en.wikipedia.org/wiki/Eon_(geology)
     http://twitter.com/YelpCincy
 

--- a/pylintrc
+++ b/pylintrc
@@ -22,7 +22,7 @@ variable-rgx=[a-z_][a-z0-9_]{0,30}$
 max-line-length=131
 
 [TYPECHECK]
-ignored-classes=pytest,RFC3986
+ignored-classes=pytest, RFC3986, _MovedItems
 
 [DESIGN]
 min-public-methods=0

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ def main():
         ],
         packages=find_packages('.', exclude=('tests*',)),
         install_requires=[
+            'six',
             'yelp_encodings',
             'yelp_bytes'
         ],

--- a/tests/_urlparse_less_special_test.py
+++ b/tests/_urlparse_less_special_test.py
@@ -8,6 +8,8 @@ http://hg.python.org/cpython/raw-file/4a17784f2fee/Lib/test/test_urlparse.py
 
 import unittest
 
+import six
+
 import yelp_uri._urlparse_less_special as urlparse
 
 
@@ -31,6 +33,19 @@ parse_qsl_test_cases = [
     ("&a=b", [('a', 'b')]),
     ("a=a+b&b=b+c", [('a', 'a b'), ('b', 'b c')]),
     ("a=1&a=2", [('a', '1'), ('a', '2')]),
+]
+
+parse_qs_test_cases = [
+    ("", {}),
+    ("&", {}),
+    ("&&", {}),
+    ("=", {'': ['']}),
+    ("=a", {'': ['a']}),
+    ("a", {'a': ['']}),
+    ("a=", {'a': ['']}),
+    ("&a=b", {'a': ['b']}),
+    ("a=a+b&b=b+c", {'a': ['a b'], 'b': ['b c']}),
+    ("a=1&a=2", {'a': ['1', '2']}),
 ]
 
 
@@ -89,6 +104,11 @@ class UrlParseTestCase(unittest.TestCase):  # pylint:disable=too-many-public-met
     def test_qsl(self):
         for orig, expect in parse_qsl_test_cases:
             result = urlparse.parse_qsl(orig, keep_blank_values=True)
+            self.assertEqual(result, expect, "Error parsing %s" % repr(orig))
+
+    def test_qs(self):
+        for orig, expect in parse_qs_test_cases:
+            result = urlparse.parse_qs(orig, keep_blank_values=True)
             self.assertEqual(result, expect, "Error parsing %s" % repr(orig))
 
     def test_roundtrips(self):
@@ -426,7 +446,7 @@ class UrlParseTestCase(unittest.TestCase):  # pylint:disable=too-many-public-met
     def test_caching(self):
         # Test case for bug #1313119
         uri = "http://example.com/doc/"
-        unicode_uri = unicode(uri)
+        unicode_uri = six.text_type(uri)
 
         urlparse.urlparse(unicode_uri)
         p = urlparse.urlparse(uri)

--- a/tests/doc_test.py
+++ b/tests/doc_test.py
@@ -1,3 +1,6 @@
+from __future__ import print_function
+
+
 def test_docs():
     from doctest import testfile
     failures, _ = testfile('README.md', module_relative=False, encoding='UTF-8')

--- a/tests/search_test.py
+++ b/tests/search_test.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+import six
+
 from yelp_uri.search import email_regex
 from yelp_uri.search import url_regex
 
@@ -21,7 +23,8 @@ def test_email_regex():
     assert_finds_email('Tom+Yelp@yahoo.com')
     assert_finds_email('info@te-aro.ca')
     assert_finds_email(u'Soirée@yelp.com')
-    assert_finds_email(u'Soirée@yelp.com'.encode('utf8'))
+    if not six.PY3:  # Regexes aren't valid for both bytes and str in py3
+        assert_finds_email(u'Soirée@yelp.com'.encode('utf8'))
     assert_finds_email('"Tom H" <Tom@yahoo.com>', 'Tom@yahoo.com')
     assert_finds_email('Email me at dave@yelp.com.', 'dave@yelp.com')
     assert_finds_email(
@@ -69,9 +72,9 @@ def test_url_regex():
     assert_finds_whole_url('www.audrey_tsang.com')
     assert_finds_whole_url('http://a.com')
     assert_finds_whole_url('http://who_even_uses_dot_mobi.mobi')
-    assert_finds_whole_url(u'http://www.yelp.com/münchen')
-    assert_finds_whole_url(u'http://www.ü.com/ü;ü;ü/ü;ü;ü?ü=ü&ü=ü#!ü/ü')
-    assert_finds_whole_url(u'http://➡.ws/➡;➡;➡/➡;➡;➡?➡=➡&➡=➡#!➡/➡')
+    assert_finds_whole_url('http://www.yelp.com/münchen')
+    assert_finds_whole_url('http://www.ü.com/ü;ü;ü/ü;ü;ü?ü=ü&ü=ü#!ü/ü')
+    assert_finds_whole_url('http://➡.ws/➡;➡;➡/➡;➡;➡?➡=➡&➡=➡#!➡/➡')
     assert_finds_whole_url('http://y.combinator')
     assert_finds_whole_url('http://.ocregion.com')
     # Ticket: #31242
@@ -113,14 +116,16 @@ def test_url_regex():
         u'中国互联网络信息中心.中国'
     )
     # We can't find internationalized TLDs in encoded strings, however.
-    assert_no_url(b'This is a website: 中国互联网络信息中心.中国. No, really.')
+    if not six.PY3:  # Regexes aren't valid for both bytes and str in py3
+        assert_no_url(u'This is a website: 中国互联网络信息中心.中国. No, really.'.encode('UTF-8'))
 
     # But we should be able to find the punycoded TLDs in both cases:
     assert_finds_url(
         u'This is a website: 中国互联网络信息中心.xn--fiqs8s. No, really.',
         u'中国互联网络信息中心.xn--fiqs8s'
     )
-    assert_finds_url(
-        b'This is a website: 中国互联网络信息中心.xn--fiqs8s. No, really.',
-        b'中国互联网络信息中心.xn--fiqs8s'
-    )
+    if not six.PY3:  # Regexes aren't valid for both bytes and str in py3
+        assert_finds_url(
+            u'This is a website: 中国互联网络信息中心.xn--fiqs8s. No, really.'.encode('UTF-8'),
+            u'中国互联网络信息中心.xn--fiqs8s'.encode('UTF-8')
+        )

--- a/tests/urllib_utf8_test.py
+++ b/tests/urllib_utf8_test.py
@@ -1,7 +1,6 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
-import urllib
-import urlparse
+import six
 
 from yelp_uri import urllib_utf8
 
@@ -19,8 +18,8 @@ def test_urlencode():
 
     # the same query, as utf-8 encoded strings
     utf8_query = dict(
-        (k.encode('utf-8'), v.encode('utf-8') if isinstance(v, unicode) else v)
-        for (k, v) in query.iteritems()
+        (k.encode('utf-8'), v.encode('utf-8') if isinstance(v, six.text_type) else v)
+        for (k, v) in query.items()
     )
 
     # Dictionaries can re-order the url params, so we
@@ -29,18 +28,18 @@ def test_urlencode():
         assert set(left.split('&')) == set(right.split('&'))
 
     assert_params_equal(urllib_utf8.urlencode(query),
-                        urllib.urlencode(utf8_query))
+                        six.moves.urllib.parse.urlencode(utf8_query))
 
     # try again, but with arrays of pairs
-    assert_params_equal(urllib_utf8.urlencode(query.items()),
-                        urllib.urlencode(utf8_query))
+    assert_params_equal(urllib_utf8.urlencode(list(query.items())),
+                        six.moves.urllib.parse.urlencode(utf8_query))
 
 
 def test_urlencode_lists():
     expected = 'exprs=foo%3A123&exprs=b%C3%A4r%3A222%F0%9F%90%B5'
 
     query = {'exprs': ['foo:123', u'bär:222🐵'.encode('UTF-8')]}
-    assert urllib.urlencode(query, True) == expected
+    assert six.moves.urllib.parse.urlencode(query, True) == expected
     assert urllib_utf8.urlencode(query, True) == expected
 
     query = {'exprs': ['foo:123', u'bär:222🐵']}
@@ -50,9 +49,9 @@ def test_urlencode_lists():
 def test_quote_and_quote_plus():
     strings = ['', 'Hello there!', u'naïve', u' San José ', ' cafés']
     for string in strings:
-        utf8_string = string.encode('utf-8') if isinstance(string, unicode) else string
-        assert urllib_utf8.quote(string) == urllib.quote(utf8_string)
-        assert urllib_utf8.quote_plus(string) == urllib.quote_plus(utf8_string)
+        utf8_string = string.encode('utf-8') if isinstance(string, six.text_type) else string
+        assert urllib_utf8.quote(string) == six.moves.urllib.parse.quote(utf8_string)
+        assert urllib_utf8.quote_plus(string) == six.moves.urllib.parse.quote_plus(utf8_string)
 
 
 def test_quote_unicode():
@@ -69,10 +68,9 @@ def test_parse_qs():
     """urllib_utf8.parse_qs should mostly act like urlparse.parse_qs."""
     strings = ['', 'foo=bar', u'foo=bar', 'foo=bar&baz=quux', 'foo=1&foo=2']
     for query_string in strings:
-        assert urllib_utf8.parse_qs(query_string) == urlparse.parse_qs(query_string)
-        utf8_string = query_string.encode('utf-8') if isinstance(query_string, unicode) else query_string
-        assert urllib_utf8.parse_qs(query_string) == urlparse.parse_qs(utf8_string)
-        assert urllib_utf8.parse_qs(query_string) == urlparse.parse_qs(utf8_string)
+        assert urllib_utf8.parse_qs(query_string) == six.moves.urllib.parse.parse_qs(query_string)
+        utf8_string = query_string.encode('utf-8') if isinstance(query_string, six.text_type) else query_string
+        assert urllib_utf8.parse_qs(utf8_string) == six.moves.urllib.parse.parse_qs(utf8_string)
 
 
 def _verify_extract_unicode_value(query_string, expected_value):

--- a/tox.ini
+++ b/tox.ini
@@ -1,17 +1,35 @@
 [tox]
 project = yelp_uri
 # These should match the travis env list
-envlist = py26,py27
+envlist = py26,py27,py34
 
 [testenv]
 install_command = pip install --use-wheel {opts} {packages}
 deps = -rrequirements_dev.txt
+passenv = LANG
 commands =
     {envpython} --version
     coverage --version
     coverage erase
     coverage run -m pytest {posargs}
     coverage report --show-missing --fail-under 96
+    flake8 --version
+    flake8 {[tox]project} tests setup.py
+    pylint --version
+    pylint {[tox]project} tests setup.py
+
+# Separate environment because urllib_utf8 re-exports python3 builtins
+# instead of using our versions, and so coverage should ignore that file
+[testenv:py34]
+install_command = pip install --use-wheel {opts} {packages}
+deps = -rrequirements_dev.txt
+passenv = LANG
+commands =
+    {envpython} --version
+    coverage --version
+    coverage erase
+    coverage run -m pytest {posargs}
+    coverage report --omit=yelp_uri/urllib_utf8.py --show-missing --fail-under 96
     flake8 --version
     flake8 {[tox]project} tests setup.py
     pylint --version

--- a/yelp_uri/__init__.py
+++ b/yelp_uri/__init__.py
@@ -11,7 +11,11 @@ Because email addresses resemble uris in several regards, we handle them under t
 # This namespace reserved for *very* general-purpse uri functions.
 
 import re
-from string import digits as DIGITS, letters as LETTERS, printable as PRINTABLE
+try:
+    from string import ascii_letters as LETTERS
+except ImportError:
+    from string import letters as LETTERS  # pylint: disable=no-name-in-module
+from string import digits as DIGITS, printable as PRINTABLE
 from collections import namedtuple
 
 import yelp_uri._urlparse_less_special as _urlparse
@@ -101,7 +105,7 @@ def netlocsplit(netloc):
     tmp.netloc = netloc
     try:
         port = tmp.port
-    except ValueError, error:
+    except ValueError as error:
         # Make this error a little more explicit and catch-able.
         if len(error.args) == 1 and type(error.args[0]) is str:
             raise MalformedUrlError('Invalid port number: ' + error.args[0])

--- a/yelp_uri/_urlparse_less_special.py
+++ b/yelp_uri/_urlparse_less_special.py
@@ -35,6 +35,8 @@ test_urlparse.py provides a good indicator of parsing behavior.
 """
 from collections import namedtuple
 
+import six
+
 
 # This is a stdlib file. To ease merging, we won't fix these style issues.
 # pylint:disable=too-many-branches,too-many-return-statements,unused-variable
@@ -315,14 +317,14 @@ _hextochr = dict((a + b, chr(int(a + b, 16))) for a in _hexdig for b in _hexdig)
 def unquote(s):
     """unquote('abc%20def') -> 'abc def'."""
     res = s.split('%')
-    for i in xrange(1, len(res)):
+    for i in range(1, len(res)):
         item = res[i]
         try:
             res[i] = _hextochr[item[:2]] + item[2:]
         except KeyError:
             res[i] = '%' + item
         except UnicodeDecodeError:
-            res[i] = unichr(int(item[:2], 16)) + item[2:]
+            res[i] = six.unichr(int(item[:2], 16)) + item[2:]
     return "".join(res)
 
 

--- a/yelp_uri/urllib_utf8.py
+++ b/yelp_uri/urllib_utf8.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# pylint: disable=no-name-in-module, unused-import, import-error, no-member
 """
 A Unicode-friendly wrapper around urllib methods that encodes unicodes into strings.
 
@@ -19,74 +20,79 @@ BAD: http://www.yelp.com/my_servlet?bäd_param=value
 ONLY use ascii for the key in url params.
 """
 
-import urllib
-import urlparse
 
 from yelp_bytes import from_utf8, to_utf8
 
+try:  # pragma: no cover
+    # Python3 supports all of these out of the box
+    from urllib.parse import parse_qs
+    from urllib.parse import quote
+    from urllib.parse import quote_plus
+    from urllib.parse import splitvalue
+    from urllib.parse import unquote
+    from urllib.parse import unquote_plus
+    from urllib.parse import urlencode
+except ImportError:
+    import six
 
-def _pairs(obj):
-    """If obj is a dict, call obj.items(), else just return obj"""
-    return obj.items() if isinstance(obj, dict) else obj
+    import urllib
+    import urlparse
 
+    def _pairs(obj):
+        """If obj is a dict, call obj.items(), else just return obj"""
+        return obj.items() if isinstance(obj, dict) else obj
 
-def urlencode(query, doseq=0):
-    """A wrapper for urllib.urlencode() that UTF-8 encodes query if
-    query is unicode. Always returns a str."""
-    # see: https://github.com/python/cpython/blob/2.7/Lib/urllib.py#L1340
-    def encode_pair(key, val):
-        if doseq and isinstance(val, (list, tuple)):
-            return to_utf8(key), [to_utf8(item) for item in val]
-        else:
-            return to_utf8(key), to_utf8(val)
+    def urlencode(query, doseq=0):
+        """A wrapper for urllib.urlencode() that UTF-8 encodes query if
+        query is unicode. Always returns a str."""
+        # see: https://github.com/python/cpython/blob/2.7/Lib/urllib.py#L1340
+        def encode_pair(key, val):
+            if doseq and isinstance(val, (list, tuple)):
+                return to_utf8(key), [to_utf8(item) for item in val]
+            else:
+                return to_utf8(key), to_utf8(val)
 
-    return urllib.urlencode([encode_pair(k, v) for (k, v) in _pairs(query)], doseq=doseq)
+        return urllib.urlencode([encode_pair(k, v) for (k, v) in _pairs(query)], doseq=doseq)
 
+    def quote(string, *args, **kwargs):
+        """A wrapper for urllib.quote() that UTF-8 encodes string if
+        query is unicode. Always returns a str."""
+        return urllib.quote(to_utf8(string), *args, **kwargs)
 
-def quote(string, *args, **kwargs):
-    """A wrapper for urllib.quote() that UTF-8 encodes string if
-    query is unicode. Always returns a str."""
-    return urllib.quote(to_utf8(string), *args, **kwargs)
+    def quote_plus(string, *args, **kwargs):
+        """A wrapper for urllib.quote_plus() that UTF-8 encodes string if
+        query is unicode. Always returns a str."""
+        assert isinstance(string, six.string_types), type(string)
+        return urllib.quote_plus(to_utf8(string), *args, **kwargs)
 
+    def unquote(string, errors='ignore'):
+        """A wrapper for urllib.unquote() that UTF-8 decodes strs.
+        Should always return a unicode.
 
-def quote_plus(string, *args, **kwargs):
-    """A wrapper for urllib.quote_plus() that UTF-8 encodes string if
-    query is unicode. Always returns a str."""
-    assert isinstance(string, basestring), type(string)
-    return urllib.quote_plus(to_utf8(string), *args, **kwargs)
+        errors - What to do on a decoding error? Default behavior is
+        to ignore bytes that we can't decode."""
+        return from_utf8(urllib.unquote(to_utf8(string)), errors=errors)
 
+    def unquote_plus(string, errors='ignore'):
+        """A wrapper for urllib.unquote_plus() that UTF-8 decodes strs.
+        Should always return a unicode.
 
-def unquote(string, errors='ignore'):
-    """A wrapper for urllib.unquote() that UTF-8 decodes strs.
-    Should always return a unicode.
+        errors - What to do on a decoding error? Default behavior is
+        to ignore bytes that we can't decode."""
+        return from_utf8(urllib.unquote_plus(to_utf8(string)), errors=errors)
 
-    errors - What to do on a decoding error? Default behavior is
-    to ignore bytes that we can't decode."""
-    return from_utf8(urllib.unquote(to_utf8(string)), errors=errors)
+    def splitvalue(string):
+        return urllib.splitvalue(to_utf8(string))
 
-
-def unquote_plus(string, errors='ignore'):
-    """A wrapper for urllib.unquote_plus() that UTF-8 decodes strs.
-    Should always return a unicode.
-
-    errors - What to do on a decoding error? Default behavior is
-    to ignore bytes that we can't decode."""
-    return from_utf8(urllib.unquote_plus(to_utf8(string)), errors=errors)
-
-
-def splitvalue(string):
-    return urllib.splitvalue(to_utf8(string))
-
-
-def parse_qs(query_string, errors='ignore'):
-    """Wrap urlparse.parse_qs() to handle URL-encoded strings stored in class unicode and similar travesties."""
-    # Actually from urlparse, not urllib; might get its own urlparse_utf8.py some day.
-    kwargs_bytes = urlparse.parse_qs(to_utf8(query_string))
-    kwargs = dict((
-        (
-            key,
-            [from_utf8(value, errors=errors) for value in value_list],
-        )
-        for key, value_list in kwargs_bytes.items()
-    ))
-    return kwargs
+    def parse_qs(query_string, errors='ignore'):
+        """Wrap urlparse.parse_qs() to handle URL-encoded strings stored in class unicode and similar travesties."""
+        # Actually from urlparse, not urllib; might get its own urlparse_utf8.py some day.
+        kwargs_bytes = urlparse.parse_qs(to_utf8(query_string))
+        kwargs = dict((
+            (
+                key,
+                [from_utf8(value, errors=errors) for value in value_list],
+            )
+            for key, value_list in kwargs_bytes.items()
+        ))
+        return kwargs


### PR DESCRIPTION
Some of the expectations don't entirely seem to port to py34 (i.e. anything coming from encode/decode uri and such could be considered bytes or str). All the associated libraries expect native str/unicode, so py34 will too.

