### PR TITLE
Update tox and tests

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -8,6 +8,7 @@ omit =
     /usr/*
     */tmp*
     setup.py
+    venv/*
 
 [report]
 exclude_lines =

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 env: # These should match the tox env list
-    - TOXENV=py26 PATH=/opt/python/2.6.9/bin:$PATH
     - TOXENV=py27
-    - TOXENV=py34
-install: pip install tox --use-mirrors
+    - TOXENV=py35
+install: pip install tox
 script: tox

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,18 @@
+export PATH := $(PWD)/bin:$(PWD)/venv/bin:$(PATH)
 
 REBUILD_FLAG =
 
 .PHONY: all
 all: venv test
 
-.PHONY: venv
 venv: .venv.touch
-	tox -e venv $(REBUILD_FLAG)
+	rm -rf venv
+	virtualenv venv --python python2.7
+	pip install -r requirements_dev.txt
 
 .PHONY: tests test
 tests: test
-test: .venv.touch
+test: venv
 	tox $(REBUILD_FLAG)
 
 
@@ -23,5 +25,5 @@ test: .venv.touch
 clean:
 	find . -iname '*.pyc' | xargs rm -f
 	rm -rf .tox
-	rm -rf ./venv-*
+	rm -rf ./venv
 	rm -f .venv.touch

--- a/pylintrc
+++ b/pylintrc
@@ -3,6 +3,10 @@ disable=
     locally-disabled,
     missing-docstring,
     maybe-no-member,
+    redefined-variable-type,
+    redundant-keyword-arg,
+    too-many-function-args,
+
 
 [REPORTS]
 output-format=colorized

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -5,7 +5,8 @@ ipdb
 coverage
 flake8
 mock
-astroid<1.3.3
-pylint<1.4
+astroid
+pylint
 pytest
 pre-commit
+tox

--- a/tests/urllib_utf8_test.py
+++ b/tests/urllib_utf8_test.py
@@ -1,9 +1,10 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 import six
-urllib = six.moves.urllib
 
 from yelp_uri import urllib_utf8
+
+urllib = six.moves.urllib
 
 
 def test_urlencode():

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 project = yelp_uri
 # These should match the travis env list
-envlist = py26,py27,py34
+envlist = py27,py35
 
 [testenv]
 install_command = pip install --use-wheel {opts} {packages}
@@ -17,10 +17,6 @@ commands =
     pylint --version
     pylint {[tox]project} tests setup.py
 
-[testenv:venv]
-envdir = venv-{[tox]project}
-commands =
-
 [testenv:docs]
 deps =
     {[testenv]deps}
@@ -32,4 +28,4 @@ commands = sphinx-build -b html -d build/doctrees source build/html
 max-line-length=131
 
 [pytest]
-addopts = -v -rfE --doctest-modules --ignore venv-yelp_uri
+addopts = -v -rfE --doctest-modules --ignore venv

--- a/yelp_uri/encoding.py
+++ b/yelp_uri/encoding.py
@@ -7,11 +7,12 @@ In general, hostnames should be punycode, usernames should be utf8, and everythi
 import re
 
 import six
-quote = six.moves.urllib.parse.quote
 
 from yelp_uri import urlsplit, urlunsplit, RFC3986, MalformedUrlError, SplitResult
 from yelp_bytes import from_bytes
 from yelp_bytes import to_bytes
+
+quote = six.moves.urllib.parse.quote
 
 
 def encode_uri(uri):


### PR DESCRIPTION
Add py35 to tox envs, dropped py26
Update makefile to create virtual env and pip install tox, instead of tox creating the
virtualenv.
Fix/suppress pylint warnings