### PR TITLE
Improve end of url detection

### DIFF
--- a/yelp_uri/__init__.py
+++ b/yelp_uri/__init__.py
@@ -64,7 +64,7 @@ class RFC3986(object):  # pylint:disable=too-many-instance-attributes
         self.userinfo = self.unreserved + '+'
 
         # Yelp extension: characters that don't belong at the end of a URI
-        self.bad_end = self.whitespace + '''<(.!'",;?:-\\'''
+        self.bad_end = self.whitespace + '''<{[(.!'",;?:-\\'''
         # The set of characters that is always OK to unescape.
         self.plaintext = self.alphanum + '_-'
         # The set of allowable URL characters.

--- a/yelp_uri/search.py
+++ b/yelp_uri/search.py
@@ -54,7 +54,7 @@ def create_url_regex(rfc3986, tlds):
                 (:\d+)? # maybe a port?
             )
             # An optional path/query/fragment component
-            (
+            (?P<path_query_fragment>
                 [/?#]
                 (
                     # Figure out if we have parens in our url


### PR DESCRIPTION
This is for the detection of uri to avoid including brackets and braces. Previously, `http://example.com[` was being picked up as the whole url.