### PR TITLE
Dropped Python 2 support and six

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,6 @@
+repos:
 -   repo: git@github.com:pre-commit/pre-commit-hooks
-    sha: ca93f6834f2afc8a8f7de46c0e02076419077c7a
+    rev: v4.4.0
     hooks:
     -   id: trailing-whitespace
         files: \.(py|sh|yaml)$
@@ -11,6 +12,16 @@
         files: \.py$
     -   id: name-tests-test
         files: tests/.+\.py$
-    -   id: flake8
-        files: \.py$
-        args: [--max-line-length=131]
+    -   id: fix-encoding-pragma
+        args:
+          - --remove
+        language_version: python3.8
+-   repo: http://github.com/asottile/reorder_python_imports
+    rev: v3.10.0
+    hooks:
+    -   id: reorder-python-imports
+-   repo: http://github.com/asottile/pyupgrade
+    rev: v3.10.1
+    hooks:
+    -   id: pyupgrade
+        args: ['--py38-plus']

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ all: venv test
 
 venv: .venv.touch
 	rm -rf venv
-	virtualenv venv --python python2.7
+	virtualenv venv --python python3.8
 	pip install -r requirements_dev.txt
 
 .PHONY: tests test

--- a/bin/generate-tlds
+++ b/bin/generate-tlds
@@ -4,9 +4,8 @@ This reads the IANA-maintained list of tlds and formats/outputs them for use
 in the domains regular expression. To regenerate:
     ./bin/generate-tlds > yelp_uri/tlds/all.py
 """
-from __future__ import unicode_literals
-from __future__ import print_function
 import sys
+
 import urllib2
 
 
@@ -42,7 +41,7 @@ from __future__ import unicode_literals
 # Generated automatically. To regenerate:
 #    ./bin/generate-tlds > yelp_uri/tlds/all.py
 all_tlds = '|'.join((
-    '{0}',
+    '{}',
 ))'''.format(domains_string).encode('UTF-8'))
 
 

--- a/pylintrc
+++ b/pylintrc
@@ -33,7 +33,6 @@ ignored-classes=
     pytest,
     RFC3986,
     _MovedItems,
-ignored-modules=six.moves
 
 [DESIGN]
 min-public-methods=0

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 def main():
     setup(
         name='yelp_uri',
-        version='2.0.0',
+        version='2.0.1',
         description="Uri utilities maintained by Yelp",
         url='https://github.com/Yelp/yelp_uri',
         author='Buck Golemon',
@@ -13,12 +13,10 @@ def main():
         platforms='all',
         classifiers=[
             'License :: Public Domain',
-            'Programming Language :: Python :: 2.7',
-            'Programming Language :: Python :: 3.5',
+            'Programming Language :: Python :: 3.8',
         ],
         packages=find_packages(exclude=('tests*',)),
         install_requires=[
-            'six>=1.11.0',
             'yelp_encodings',
             'yelp_bytes'
         ],

--- a/tests/_urlparse_less_special_test.py
+++ b/tests/_urlparse_less_special_test.py
@@ -1,14 +1,10 @@
 #! /usr/bin/env python
-# -*- coding: utf-8 -*-
 """Tests are also pulled from stdlib 2.6
 This file is space-indented to ease merging from upstream.
 
 http://hg.python.org/cpython/raw-file/4a17784f2fee/Lib/test/test_urlparse.py
 """
-
 import unittest
-
-import six
 
 import yelp_uri._urlparse_less_special as urlparse
 
@@ -446,7 +442,7 @@ class UrlParseTestCase(unittest.TestCase):
     def test_caching(self):
         # Test case for bug #1313119
         uri = "http://example.com/doc/"
-        unicode_uri = six.text_type(uri)
+        unicode_uri = str(uri)
 
         urlparse.urlparse(unicode_uri)
         p = urlparse.urlparse(uri)

--- a/tests/encoding_test.py
+++ b/tests/encoding_test.py
@@ -1,6 +1,4 @@
-# -*- coding: utf-8 -*-
 import pytest
-import six
 
 import yelp_uri.encoding as E
 from yelp_uri.urllib_utf8 import quote
@@ -22,17 +20,14 @@ def test_bad_domain_segment_too_long():
     try:
         E.encode_uri('http://foo.%s.bar' % ('x' * 64))
     except E.MalformedUrlError as error:
-        if six.PY3:
-            error_msg = (
-                "Invalid hostname: encoding with 'IDNA' codec failed "
-                "(UnicodeError: label empty or too long): "
-            )
-        else:
-            error_msg = 'Invalid hostname: label empty or too long: '
+        error_msg = (
+            "Invalid hostname: encoding with 'IDNA' codec failed "
+            "(UnicodeError: label empty or too long): "
+        )
 
         assert error.args == (
             error_msg +
-            repr(u"foo.xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.bar"),
+            repr("foo.xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.bar"),
         )
 
 
@@ -47,44 +42,44 @@ def test_recode_none_raises_attribute_error():
 
 
 def test_unicode_url_gets_quoted():
-    url = u'http://www.yelp.com/münchen'
+    url = 'http://www.yelp.com/münchen'
     assert E.recode_uri(url) == 'http://www.yelp.com/m%C3%BCnchen'
 
 
 def test_mixed_quoting_url():
     """Test that a url with mixed quoting has uniform quoting after requoting"""
-    url = u'http://www.yelp.com/m%C3%BCnchen/münchen'
+    url = 'http://www.yelp.com/m%C3%BCnchen/münchen'
     assert E.recode_uri(url) == 'http://www.yelp.com/m%C3%BCnchen/m%C3%BCnchen'
 
 
 def test_mixed_quoting_param():
     """Tests that a url with mixed quoting in the parameters has uniform quoting after requoting"""
-    url = u'http://www.yelp.com?m%C3%BCnchen=münchen'
+    url = 'http://www.yelp.com?m%C3%BCnchen=münchen'
     assert E.recode_uri(url) == 'http://www.yelp.com?m%C3%BCnchen=m%C3%BCnchen'
 
 
 def test_mixed_encoding():
     """Tests that a url with mixed encoding has uniform encoding after recoding"""
-    url = u'http://www.yelp.com/m%C3%BCnchen?m%FCnchen'
+    url = 'http://www.yelp.com/m%C3%BCnchen?m%FCnchen'
     assert E.recode_uri(url) == 'http://www.yelp.com/m%C3%BCnchen?m%C3%BCnchen'
 
 
 def test_mixed_quoting_multiple_queries():
     """Tests that a url with mixed quoting in multiple parameters has uniform quoting after requoting"""
-    url = u'http://yelp.com/münchen/m%C3%BCnchen?münchen=m%C3%BCnchen&htmlchars=<">'
+    url = 'http://yelp.com/münchen/m%C3%BCnchen?münchen=m%C3%BCnchen&htmlchars=<">'
     assert E.recode_uri(url) == \
         'http://yelp.com/m%C3%BCnchen/m%C3%BCnchen?m%C3%BCnchen=m%C3%BCnchen&htmlchars=%3C%22%3E'
 
 
 def test_utf8_url():
     """Tests that a url with mixed quoting in multiple parameters has uniform quoting after requoting"""
-    url = u'http://yelp.com/münchen/m%C3%BCnchen?münchen=m%C3%BCnchen&htmlchars=<">'.encode('utf-8')
+    url = 'http://yelp.com/münchen/m%C3%BCnchen?münchen=m%C3%BCnchen&htmlchars=<">'.encode()
     assert E.recode_uri(url) == \
         'http://yelp.com/m%C3%BCnchen/m%C3%BCnchen?m%C3%BCnchen=m%C3%BCnchen&htmlchars=%3C%22%3E'
 
 
 def test_multiple_escapes():
-    url = u'http://münch.com?zero=münch&one=m%C3%BCnch&two=m%25C3%25BCnch&three=m%2525C3%2525BCnch'
+    url = 'http://münch.com?zero=münch&one=m%C3%BCnch&two=m%25C3%25BCnch&three=m%2525C3%2525BCnch'
     assert E.recode_uri(url) == \
         'http://xn--mnch-0ra.com?zero=m%C3%BCnch&one=m%C3%BCnch&two=m%25C3%25BCnch&three=m%2525C3%2525BCnch'
 
@@ -129,29 +124,29 @@ def test_param_xss():
 def test_letters_recoding():
     """Tests that alphanumeric escapes get unquoted in recode_uri."""
     url = (
-        u'http://💩.la/%74%68%69%73%5f%69%73%5f%61%5f%70%61%74%68'
-        u'?a=b%3f%63&%64%3D%65=f#%73%70%61%63%65%73 %61%72%65 %64%61%6e%67%65%72%6f%75%73'
+        'http://💩.la/%74%68%69%73%5f%69%73%5f%61%5f%70%61%74%68'
+        '?a=b%3f%63&%64%3D%65=f#%73%70%61%63%65%73 %61%72%65 %64%61%6e%67%65%72%6f%75%73'
     )
     assert E.recode_uri(url) == \
         'http://xn--ls8h.la/this_is_a_path?a=b%3fc&d%3De=f#spaces%20are%20dangerous'
 
 
 def worst_case(strange_character):
-    u"""
+    """
     generate a worst-case url, using a "strange" character
 
     >>> print(worst_case(u'ü'))
     http://ü:ü@www.ü.com/ü;ü;ü/ü;ü;ü?ü=ü&ü=ü#!ü/ü
     """
     template = ('http://', ':', '@www.', '.com/', ';', ';', '/', ';', ';', '?', '=', '&', '=', '#!', '/', '')
-    if isinstance(strange_character, six.binary_type):
+    if isinstance(strange_character, bytes):
         template = (part.encode('US-ASCII') for part in template)
     return strange_character.join(template)
 
 
 def test_worst_case_unicode():
     # Test both unicode and utf8-bytes
-    for umlaut in (u'ü', 'ü'):
+    for umlaut in ('ü', 'ü'):
         strange_url = worst_case(umlaut)
         normalized_url = E.recode_uri(strange_url)
 
@@ -177,7 +172,7 @@ def test_worst_case_ascii():
 def test_bad_bytes():
     # This is unlikely to happen except due to gross programming error,
     # but I want to show what *would* happen.
-    for bad_stuff in (u'\xFF', b'\xFF', u'%FF', b'%FF'):
+    for bad_stuff in ('\xFF', b'\xFF', '%FF', b'%FF'):
         strange_url = worst_case(bad_stuff)
         normalized_url = E.recode_uri(strange_url)
 
@@ -240,10 +235,10 @@ def test_path_only_url():
 
 
 examples = pytest.mark.parametrize(('charname', 'chars', 'pathchars', 'expected_url'), [
-    ('latin1', u'ü', u'\x81', 'http://xn--mnchen-3ya.com/m%C3%BCchen/%C2%81'),
-    ('win1252', u'€', '', 'http://xn--mnchen-ic1c.com/m%E2%82%ACchen/'),
-    ('utf8', u'プŁ☃', '', 'http://xn--mnchen-3db6836e0mua.com/m%E3%83%97%C5%81%E2%98%83chen/'),
-    ('emoji', u'🐱', '', 'http://xn--mnchen-i844e.com/m%F0%9F%90%B1chen/'),
+    ('latin1', 'ü', '\x81', 'http://xn--mnchen-3ya.com/m%C3%BCchen/%C2%81'),
+    ('win1252', '€', '', 'http://xn--mnchen-ic1c.com/m%E2%82%ACchen/'),
+    ('utf8', 'プŁ☃', '', 'http://xn--mnchen-3db6836e0mua.com/m%E3%83%97%C5%81%E2%98%83chen/'),
+    ('emoji', '🐱', '', 'http://xn--mnchen-i844e.com/m%F0%9F%90%B1chen/'),
     ('ascii', '-._~%', "!$&'()*+,;=:@", "http://m-._~%nchen.com/m-._~%chen/!$&'()*+,;=:@")
 ])
 
@@ -251,7 +246,7 @@ examples = pytest.mark.parametrize(('charname', 'chars', 'pathchars', 'expected_
 @examples
 def test_recode_unicode(charname, chars, pathchars, expected_url):
     del charname  # passed, but unused
-    url_template = u"http://m{chars}nchen.com/m{chars}chen/{pathchars}"
+    url_template = "http://m{chars}nchen.com/m{chars}chen/{pathchars}"
     unicode_url = url_template.format(chars=chars, pathchars=pathchars)
     assert E.recode_uri(unicode_url) == expected_url
 
@@ -259,7 +254,7 @@ def test_recode_unicode(charname, chars, pathchars, expected_url):
 @examples
 @pytest.mark.parametrize('encoding', ('latin1', 'windows-1252', 'utf8', 'ascii'))
 def test_recode_encoded(charname, chars, pathchars, expected_url, encoding):
-    url_template = u"http://m{chars}nchen.com/m{chars}chen/{pathchars}"
+    url_template = "http://m{chars}nchen.com/m{chars}chen/{pathchars}"
     unicode_url = url_template.format(chars=chars, pathchars=pathchars)
 
     try:
@@ -280,9 +275,9 @@ def test_recode_encoded(charname, chars, pathchars, expected_url, encoding):
         assert E.recode_uri(quoted_url) == expected_url
 
 
-class TestUnquoteBytes(object):
-    ASCII = b''.join(six.int2byte(c) for c in range(0x80))
-    NON_ASCII = b''.join(six.int2byte(c) for c in range(0x80, 0x100))
+class TestUnquoteBytes:
+    ASCII = b''.join(bytes((c,)) for c in range(0x80))
+    NON_ASCII = b''.join(bytes((c,)) for c in range(0x80, 0x100))
 
     @staticmethod
     def assert_unquote_bytes(input_value, expected):
@@ -308,12 +303,12 @@ class TestUnquoteBytes(object):
         self.assert_unquote_bytes(quoted_url, unquoted_url)
 
 
-class TestRecodeEmail(object):
-    munchen = u'münchen'
-    email = u'{munchen}@{munchen}.com?subject={munchen}'.format(munchen=munchen)
+class TestRecodeEmail:
+    munchen = 'münchen'
+    email = '{munchen}@{munchen}.com?subject={munchen}'.format(munchen=munchen)
 
     # The username is best encoded as simply utf8.
-    expected = u'{utf8_munchen}@{idna_munchen}.com?subject={percent_munchen}'.format(
+    expected = '{utf8_munchen}@{idna_munchen}.com?subject={percent_munchen}'.format(
         utf8_munchen=munchen,
         idna_munchen=munchen.encode('IDNA').decode('US-ASCII'),
         percent_munchen=quote(munchen.encode('UTF-8')),
@@ -324,7 +319,7 @@ class TestRecodeEmail(object):
         assert E.encode_email('') == ''
 
     def test_not_an_email(self):
-        not_an_email = u"They don't use email in " + self.munchen
+        not_an_email = "They don't use email in " + self.munchen
         assert E.encode_email(not_an_email) == not_an_email.encode('IDNA').decode('US-ASCII')
 
     def test_encode_email(self):

--- a/tests/search_test.py
+++ b/tests/search_test.py
@@ -1,6 +1,4 @@
-# -*- coding: utf-8 -*-
 import pytest
-import six
 
 from yelp_uri.search import email_regex
 from yelp_uri.search import url_regex
@@ -16,7 +14,7 @@ def test_email_regex():
         match = email_regex.search(text)
         assert match
         user, domain = match.groups()
-        assert '%s@%s' % (user, domain) == email
+        assert f'{user}@{domain}' == email
 
     def assert_no_email(text):
         assert not email_regex.search(text)
@@ -24,9 +22,7 @@ def test_email_regex():
     assert_finds_email('i_love_yelp@yahoo.com')
     assert_finds_email('Tom+Yelp@yahoo.com')
     assert_finds_email('info@te-aro.ca')
-    assert_finds_email(u'Soirée@yelp.com')
-    if not six.PY3:  # Regexes aren't valid for both bytes and str in py3
-        assert_finds_email(u'Soirée@yelp.com'.encode('utf8'))
+    assert_finds_email('Soirée@yelp.com')
     assert_finds_email('"Tom H" <Tom@yahoo.com>', 'Tom@yahoo.com')
     assert_finds_email('Email me at dave@yelp.com.', 'dave@yelp.com')
     assert_finds_email(
@@ -40,7 +36,7 @@ def test_email_regex():
     assert_no_email('Log in with http://guest@example.com...')
 
 
-class RegexAssertion(object):
+class RegexAssertion:
     def __init__(self, regex):
         self.url_regex = regex
 
@@ -81,9 +77,9 @@ def assert_url_regex(regex_assert):
     regex_assert.finds_whole_url('www.audrey_tsang.com')
     regex_assert.finds_whole_url('http://a.com')
     regex_assert.finds_whole_url('http://who_even_uses_dot_mobi.mobi')
-    regex_assert.finds_whole_url(u'http://www.yelp.com/münchen')
-    regex_assert.finds_whole_url(u'http://www.ü.com/ü;ü;ü/ü;ü;ü?ü=ü&ü=ü#!ü/ü')
-    regex_assert.finds_whole_url(u'http://➡.ws/➡;➡;➡/➡;➡;➡?➡=➡&➡=➡#!➡/➡')
+    regex_assert.finds_whole_url('http://www.yelp.com/münchen')
+    regex_assert.finds_whole_url('http://www.ü.com/ü;ü;ü/ü;ü;ü?ü=ü&ü=ü#!ü/ü')
+    regex_assert.finds_whole_url('http://➡.ws/➡;➡;➡/➡;➡;➡?➡=➡&➡=➡#!➡/➡')
     regex_assert.finds_whole_url('http://y.combinator')
     regex_assert.finds_whole_url('http://.ocregion.com')
 
@@ -163,23 +159,15 @@ def test_url_regex_i18n():
 
     # We now know the list of non-ascii top-level domains as well:
     a.finds_url(
-        u'This is a website: 中国互联网络信息中心.中国. No, really.',
-        u'中国互联网络信息中心.中国'
+        'This is a website: 中国互联网络信息中心.中国. No, really.',
+        '中国互联网络信息中心.中国'
     )
-    # We can't find internationalized TLDs in encoded strings, however.
-    if not six.PY3:  # Regexes aren't valid for both bytes and str in py3
-        a.finds_no_url(u'This is a website: 中国互联网络信息中心.中国. No, really.'.encode('UTF-8'))
 
     # But we should be able to find the punycoded TLDs in both cases:
     a.finds_url(
-        u'This is a website: 中国互联网络信息中心.xn--fiqs8s. No, really.',
-        u'中国互联网络信息中心.xn--fiqs8s'
+        'This is a website: 中国互联网络信息中心.xn--fiqs8s. No, really.',
+        '中国互联网络信息中心.xn--fiqs8s'
     )
-    if not six.PY3:  # Regexes aren't valid for both bytes and str in py3
-        a.finds_url(
-            u'This is a website: 中国互联网络信息中心.xn--fiqs8s. No, really.'.encode('UTF-8'),
-            u'中国互联网络信息中心.xn--fiqs8s'.encode('UTF-8')
-        )
 
 
 @pytest.mark.parametrize('test_input,expected', [

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 project = yelp_uri
 # These should match the travis env list
-envlist = py27,py36
+envlist = py38
 
 [testenv]
 deps = -rrequirements_dev.txt

--- a/yelp_uri/__init__.py
+++ b/yelp_uri/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 The python standard library is a bit deficient in its handling of urls.
 This namespace contains the yelp extensions to the stdlib functionality.
@@ -9,7 +8,6 @@ Where RFC3986 is incompatible with RFC2396 (the older, obsoleted standard), we p
 Because email addresses resemble uris in several regards, we handle them under this namespace as well.
 """
 # This namespace reserved for *very* general-purpse uri functions.
-
 import re
 try:
     from string import ascii_letters as LETTERS
@@ -18,7 +16,6 @@ except ImportError:
 from string import digits as DIGITS, printable as PRINTABLE
 from collections import namedtuple
 
-import six
 from yelp_bytes import from_bytes
 
 import yelp_uri._urlparse_less_special as _urlparse
@@ -31,7 +28,7 @@ class MalformedUrlError(UnicodeError):
     pass
 
 
-class RFC3986(object):
+class RFC3986:
     """
     Codify some knowlege about the characters in a URL
     From:
@@ -73,7 +70,7 @@ class RFC3986(object):
         self.re = self.produce_character_classes()
 
     def produce_character_classes(self):
-        class RFC3986re(object):
+        class RFC3986re:
             pass
 
         for attr, val in vars(self).items():
@@ -154,7 +151,7 @@ def urlsplit(url):
     return -- a yelp.uri.SplitResult
     """
     url = _urlparse.urlsplit(
-        from_bytes(url) if isinstance(url, six.binary_type) else url
+        from_bytes(url) if isinstance(url, bytes) else url
     )
     nl = netlocsplit(url.netloc)
     return SplitResult(url.scheme, nl.username, nl.password, nl.hostname, nl.port, url.path, url.query, url.fragment)

--- a/yelp_uri/_urlparse_less_special.py
+++ b/yelp_uri/_urlparse_less_special.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # vim:et:sts=4:ts=4
 """
 This is a copy of the python2.6 stdlib urlparse with special cases factored out.
@@ -35,8 +34,6 @@ test_urlparse.py provides a good indicator of parsing behavior.
 """
 from collections import namedtuple
 
-import six
-
 
 # This is a stdlib file. To ease merging, we won't fix these style issues.
 
@@ -58,7 +55,7 @@ def clear_cache():
     _parse_cache.clear()
 
 
-class ResultMixin(object):
+class ResultMixin:
     """Shared methods for the parsed result objects."""
 
     @property
@@ -209,7 +206,7 @@ def urlunparse(data):
     (the draft states that these are equivalent)."""
     scheme, netloc, url, params, query, fragment = data
     if params:
-        url = "%s;%s" % (url, params)
+        url = f"{url};{params}"
     return urlunsplit((scheme, netloc, url, query, fragment))
 
 
@@ -309,7 +306,7 @@ def urldefrag(url):
 
 
 _hexdig = '0123456789ABCDEFabcdef'
-_hextochr = dict((a + b, chr(int(a + b, 16))) for a in _hexdig for b in _hexdig)
+_hextochr = {a + b: chr(int(a + b, 16)) for a in _hexdig for b in _hexdig}
 
 
 def unquote(s):
@@ -322,7 +319,7 @@ def unquote(s):
         except KeyError:
             res[i] = '%' + item
         except UnicodeDecodeError:
-            res[i] = six.unichr(int(item[:2], 16)) + item[2:]
+            res[i] = chr(int(item[:2], 16)) + item[2:]
     return "".join(res)
 
 
@@ -380,7 +377,7 @@ def parse_qsl(qs, keep_blank_values=0, strict_parsing=0):
         nv = name_value.split('=', 1)
         if len(nv) != 2:
             if strict_parsing:
-                raise ValueError("bad query field: %r" % (name_value,))
+                raise ValueError(f"bad query field: {name_value!r}")
             # Handle case of a control-name with no equal sign
             if keep_blank_values:
                 nv.append('')

--- a/yelp_uri/encoding.py
+++ b/yelp_uri/encoding.py
@@ -1,18 +1,19 @@
-# -*- coding: utf-8 -*-
 """Handle encoding of uris.
 
 This is complicated since a uri consists of several parts with non-uniform encoding schemes.
 In general, hostnames should be punycode, usernames should be utf8, and everything else should be urlquote+utf8.
 """
 import re
+import urllib.parse
 
-import six
-
-from yelp_uri import urlsplit, urlunsplit, RFC3986, MalformedUrlError, SplitResult
 from yelp_bytes import from_bytes
 from yelp_bytes import to_bytes
 
-quote = six.moves.urllib.parse.quote
+from yelp_uri import MalformedUrlError
+from yelp_uri import RFC3986
+from yelp_uri import SplitResult
+from yelp_uri import urlsplit
+from yelp_uri import urlunsplit
 
 
 def encode_uri(uri):
@@ -147,7 +148,7 @@ def _encode(string, encoding='UTF-8', expected='', quoted=True):
     if encoding:
         string = string.encode(encoding)
         if quoted:
-            string = quote(string, expected)
+            string = urllib.parse.quote(string, expected)
         else:
             string = string.decode('ASCII')
 
@@ -168,7 +169,7 @@ def _encode_hostname(hostname):
     except UnicodeError as error:
         # Make this error a little more explicit and catch-able.
         if len(error.args) == 1 and isinstance(error.args[0], str):
-            raise MalformedUrlError('Invalid hostname: %s: %r' % (error.args[0], hostname))
+            raise MalformedUrlError(f'Invalid hostname: {error.args[0]}: {hostname!r}')
         else:  # An exception I don't expect
             raise
 
@@ -211,7 +212,7 @@ def _unquote_bytes(string):
         except ValueError:
             res[i] = b'%' + item
         else:
-            char = six.int2byte(c)
+            char = bytes((c,))
             if (
                     c >= 0x80 or
                     char in _ascii_plaintext

--- a/yelp_uri/search.py
+++ b/yelp_uri/search.py
@@ -1,9 +1,8 @@
-# -*- coding: utf-8 -*-
 import re
 
-from yelp_uri import RFC3986
 from .tlds.all import all_tlds
 from .tlds.common import common_tlds
+from yelp_uri import RFC3986
 
 
 def create_url_regex(rfc3986, tlds):

--- a/yelp_uri/tlds/all.py
+++ b/yelp_uri/tlds/all.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
 # Generated automatically. To regenerate:
 #    ./bin/generate-tlds > yelp_uri/tlds/all.py
 all_tlds = '|'.join((

--- a/yelp_uri/urllib_utf8.py
+++ b/yelp_uri/urllib_utf8.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 A Unicode-friendly wrapper around urllib methods that encodes unicodes into strings.
 
@@ -18,77 +17,11 @@ BAD: http://www.yelp.com/my_servlet?bäd_param=value
 
 ONLY use ascii for the key in url params.
 """
-import six
-
-if six.PY3:
-    # Python3 supports all of these out of the box
-    from urllib.parse import parse_qs
-    from urllib.parse import quote
-    from urllib.parse import quote_plus
-    from urllib.parse import splitvalue
-    from urllib.parse import unquote
-    from urllib.parse import unquote_plus
-    from urllib.parse import urlencode
-else:
-    urlparse = six.moves.urllib.parse
-
-    from yelp_bytes import from_utf8, to_utf8
-
-    def _pairs(obj):
-        """If obj is a dict, call obj.items(), else just return obj"""
-        return obj.items() if isinstance(obj, dict) else obj
-
-    def urlencode(query, doseq=0):
-        """A wrapper for urllib.urlencode() that UTF-8 encodes query if
-        query is unicode. Always returns a str."""
-        # see: https://github.com/python/cpython/blob/2.7/Lib/urllib.py#L1340
-        def encode_pair(key, val):
-            if doseq and isinstance(val, (list, tuple)):
-                return to_utf8(key), [to_utf8(item) for item in val]
-            else:
-                return to_utf8(key), to_utf8(val)
-
-        return urlparse.urlencode([encode_pair(k, v) for (k, v) in _pairs(query)], doseq=doseq)
-
-    def quote(string, *args, **kwargs):
-        """A wrapper for urllib.quote() that UTF-8 encodes string if
-        query is unicode. Always returns a str."""
-        return urlparse.quote(to_utf8(string), *args, **kwargs)
-
-    def quote_plus(string, *args, **kwargs):
-        """A wrapper for urllib.quote_plus() that UTF-8 encodes string if
-        query is unicode. Always returns a str."""
-        assert isinstance(string, six.string_types), type(string)
-        return urlparse.quote_plus(to_utf8(string), *args, **kwargs)
-
-    def unquote(string, errors='ignore'):
-        """A wrapper for urllib.unquote() that UTF-8 decodes strs.
-        Should always return a unicode.
-
-        errors - What to do on a decoding error? Default behavior is
-        to ignore bytes that we can't decode."""
-        return from_utf8(urlparse.unquote(to_utf8(string)), errors=errors)
-
-    def unquote_plus(string, errors='ignore'):
-        """A wrapper for urllib.unquote_plus() that UTF-8 decodes strs.
-        Should always return a unicode.
-
-        errors - What to do on a decoding error? Default behavior is
-        to ignore bytes that we can't decode."""
-        return from_utf8(urlparse.unquote_plus(to_utf8(string)), errors=errors)
-
-    def splitvalue(string):
-        return urlparse.splitvalue(to_utf8(string))
-
-    def parse_qs(query_string, errors='ignore'):
-        """Wrap urlparse.parse_qs() to handle URL-encoded strings stored in class unicode and similar travesties."""
-        # Actually from urlparse, not urllib; might get its own urlparse_utf8.py some day.
-        kwargs_bytes = urlparse.parse_qs(to_utf8(query_string))
-        kwargs = dict((
-            (
-                key,
-                [from_utf8(value, errors=errors) for value in value_list],
-            )
-            for key, value_list in kwargs_bytes.items()
-        ))
-        return kwargs
+# flake8: noqa
+from urllib.parse import parse_qs
+from urllib.parse import quote
+from urllib.parse import quote_plus
+from urllib.parse import splitvalue
+from urllib.parse import unquote
+from urllib.parse import unquote_plus
+from urllib.parse import urlencode


### PR DESCRIPTION
Mostly automated code changes via pre-commit, then some cleanups.

Dropping Python 2 and six.
This package is used by quite a few packages and it seems the easiest way to get rid of six.